### PR TITLE
fix(ksef): Dodanie obsługi user_companies dla dostępu do firm w RBAC

### DIFF
--- a/new-architecture/components/opa-standalone/policies/ksef.rego
+++ b/new-architecture/components/opa-standalone/policies/ksef.rego
@@ -126,6 +126,16 @@ company_access_granted if {
     assignment.role_name in ["Administrator", "Wlasciciel_KA"]
 }
 
+# Model 1 (RBAC): dostęp przez bezpośrednie przypisanie firmy do użytkownika
+company_access_granted if {
+    input.company_id
+    
+    # Sprawdzamy czy użytkownik ma bezpośredni dostęp do firmy
+    some user_company in data.acl[input.tenant].data.user_companies
+    user_company.user_id == input.user
+    user_company.company_id == input.company_id
+}
+
 company_access_granted if {
     input.company_id
     


### PR DESCRIPTION
- Dodano regułę company_access_granted dla bezpośredniego dostępu użytkownika do firm
- Naprawiono problem z brakiem dostępu Handlowca do przypisanych firm
- Model RBAC: Administrator/Wlasciciel_KA → wszystkie firmy, inne role → user_companies
- Model ReBAC: dostęp przez team_companies dla zespołów